### PR TITLE
chore: ajout du sentry-eye-roadmap.md à ignorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Prerequisites
 *.d
+sentry-eye-roadmap.md
 
 # Object files
 *.o

--- a/code/sketch.ino
+++ b/code/sketch.ino
@@ -11,11 +11,11 @@ int val = 0;
 LiquidCrystal_I2C lcd(0x27, 16, 2);
 
 void alerte(int mode) {
-    if(mode == 1) {
-      tone(BUZZER_PIN, 600);
-    }else {
-      noTone(BUZZER_PIN);
-    }
+  if(mode == 1) {
+    tone(BUZZER_PIN, 600);
+  }else {
+    noTone(BUZZER_PIN);
+  }
 }
 
 void setup() {
@@ -63,3 +63,4 @@ void loop() {
 
   delay(100);
 }
+


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Ignore sentry-eye-roadmap.md in the .gitignore